### PR TITLE
changed duration parsing to ms

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -36,7 +36,6 @@ exports.init = function () {
           album: item.snippet.description,
           artist: item.snippet.channelTitle,
           artwork: item.snippet.thumbnails.default.url,
-          duration: item.snippet.duration,
           confidence: 0.5
         }
       })

--- a/lib/media.js
+++ b/lib/media.js
@@ -97,16 +97,18 @@ exports.setTrack = function (item, callback) {
       callback(err)
       return
     }
-    var duration;
+    var duration = 0
     if (item.contentDetails && item.contentDetails.duration) {
       duration = util.parsePeriod(item.contentDetails.duration)
+      // return duration in milliseconds
+      duration = duration * 1000
     }
-    // return duration in milliseconds
-    duration = duration * 1000;
+    
     // if we have a negative or 0 duration omit it altogether
     if (duration < 1) {
-      duration = undefined;
+      duration = undefined
     }
+    
     Homey.manager('media').setTrack({
       id: id,
       title: item.snippet.title,

--- a/lib/media.js
+++ b/lib/media.js
@@ -36,7 +36,7 @@ exports.init = function () {
           album: item.snippet.description,
           artist: item.snippet.channelTitle,
           artwork: item.snippet.thumbnails.default.url,
-          duration: 0,
+          duration: item.snippet.duration,
           confidence: 0.5
         }
       })
@@ -97,9 +97,15 @@ exports.setTrack = function (item, callback) {
       callback(err)
       return
     }
-    var duration = 0
+    var duration;
     if (item.contentDetails && item.contentDetails.duration) {
       duration = util.parsePeriod(item.contentDetails.duration)
+    }
+    // return duration in milliseconds
+    duration = duration * 1000;
+    // if we have a negative or 0 duration omit it altogether
+    if (duration < 1) {
+      duration = undefined;
     }
     Homey.manager('media').setTrack({
       id: id,


### PR DESCRIPTION
- Changed the parsing of the Track duration to milliseconds to prevent a playback bug mentioned in #4  with the Homey Media Manager.

I haven't thoroughly tested this yet so I do not know how it could potentially influence your current setup.

I also noticed that some videos would not play directly on Homey itself. Was this an existing issue before? ( I have limited experience with using the app myself )
